### PR TITLE
Fix Sentry3 voltage sensor discovery

### DIFF
--- a/includes/discovery/sensors/voltage/sentry3.inc.php
+++ b/includes/discovery/sensors/voltage/sentry3.inc.php
@@ -10,7 +10,7 @@ foreach ($oids as $index => $first) {
             $valid['sensor'],
             'voltage',
             $device,
-            ".1.3.6.1.4.1.1718.3.2.2.1.11.1.$index.$end",
+            ".1.3.6.1.4.1.1718.3.2.2.1.11.$index.$end",
             $index,
             'sentry3',
             'Tower ' . $index,


### PR DESCRIPTION
Previous fix broke voltage sensor discovery with superfluous .1 in the SNMP OID.  I have fixed my install with this patch but other testing should probably be done.

DO NOT DELETE THIS TEXT

#### Please note

> Please read this information carefully. You can run `./scripts/pre-commit.php` to check your code before submitting.

- [x] Have you followed our [code guidelines?](http://docs.librenms.org/Developing/Code-Guidelines/)

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
